### PR TITLE
Use typeinfo

### DIFF
--- a/NullabilityInference.Tests/InferenceTests.cs
+++ b/NullabilityInference.Tests/InferenceTests.cs
@@ -531,14 +531,14 @@ class Program
         }
 
         [Fact]
-        public void ConstructNewNullableValue()
+        public void ConstructNewNullableValueDoesNotThrow()
         {
             AssertNullabilityInference(@"
 using System;
 
 public class SomeContext
 {
-    public Nullable<int> NullableValue = 1.ToString() != 2.ToString() ? default(int?) : new int?(3);
+    public object NullableValue = new int?(3);
 }
 ");
         }

--- a/NullabilityInference.Tests/InferenceTests.cs
+++ b/NullabilityInference.Tests/InferenceTests.cs
@@ -531,6 +531,19 @@ class Program
         }
 
         [Fact]
+        public void ConstructNewNullableValue()
+        {
+            AssertNullabilityInference(@"
+using System;
+
+public class SomeContext
+{
+    public Nullable<int> NullableValue = 1.ToString() != 2.ToString() ? default(int?) : new int?(3);
+}
+");
+        }
+
+        [Fact]
         public void EventsInInterface()
         {
             AssertNullabilityInference(@"

--- a/NullabilityInference.Tests/NullabilityTestHelper.cs
+++ b/NullabilityInference.Tests/NullabilityTestHelper.cs
@@ -65,7 +65,7 @@ namespace ICSharpCode.NullabilityInference.Tests.NullabilityInference
             compilation = AllNullableSyntaxRewriter.MakeAllReferenceTypesNullable(compilation, cancellationToken);
             string allNullableText = compilation.SyntaxTrees.Single().GetText().ToString();
             foreach (var diag in compilation.GetDiagnostics(cancellationToken)) {
-                Assert.False(diag.Severity == DiagnosticSeverity.Error, diag.ToString());
+                Assert.False(diag.Severity == DiagnosticSeverity.Error, diag.ToString() + "\r\n\r\nSource:\r\n" + program);
             }
             var engine = new NullCheckingEngine(compilation);
             engine.Analyze(cancellationToken);
@@ -74,7 +74,7 @@ namespace ICSharpCode.NullabilityInference.Tests.NullabilityInference
 
         protected static void AssertNullabilityInference(string expectedProgram, string inputProgram = null, CancellationToken cancellationToken = default)
         {
-            inputProgram ??= Regex.Replace(expectedProgram, "(?<![?])[?](?![?.])", "");
+            inputProgram ??= Regex.Replace(expectedProgram, @"(?<![?\s])[?](?![?.\(\)])", "");
             var (_, engine) = CompileAndAnalyze(inputProgram, cancellationToken);
             var newSyntax = engine.ConvertSyntaxTrees(cancellationToken).Single();
             string outputProgram = newSyntax.GetText(cancellationToken).ToString();

--- a/NullabilityInference/GraphBuildingSyntaxVisitor.cs
+++ b/NullabilityInference/GraphBuildingSyntaxVisitor.cs
@@ -119,8 +119,8 @@ namespace ICSharpCode.NullabilityInference
         {
             var ty = node.ElementType.Accept(this);
             if (ty.Type?.IsValueType == true) {
-                var symbolInfo = semanticModel.GetSymbolInfo(node, cancellationToken);
-                if (symbolInfo.Symbol is INamedTypeSymbol { OriginalDefinition: { SpecialType: SpecialType.System_Nullable_T } } nullableType) {
+                var typeInfo = semanticModel.GetTypeInfo(node, cancellationToken);
+                if (typeInfo.Type is INamedTypeSymbol { OriginalDefinition: { SpecialType: SpecialType.System_Nullable_T } } nullableType) {
                     return new TypeWithNode(nullableType, typeSystem.ObliviousNode, new[] { ty });
                 } else {
                     throw new NotSupportedException("NullableType should resolve to System_Nullable_T");


### PR DESCRIPTION
Switches to using GetTypeInfo directly rather than trying to navigate through the symbol which occasionally is an IMethodSymbol for example