### PR TITLE
Deconstruct non tuple

### DIFF
--- a/NullabilityInference.Tests/InferenceTests.cs
+++ b/NullabilityInference.Tests/InferenceTests.cs
@@ -1175,6 +1175,31 @@ class Program {
         }
 
         [Fact]
+        public void DeconstructNonTuple()
+        {
+            AssertNullabilityInference(@"
+public class AnyContext
+{
+    public void Caller()
+    {
+        (float f, int i) = new Deconstructable<float>(3f);
+    }
+}
+
+public class Deconstructable<T>
+{
+    public Deconstructable(T t) => _t = t;
+    private T _t;
+
+    public void Deconstruct(out T x, out int y)
+    {
+        x = _t;
+        y = 5;
+    }
+}");
+        }
+
+        [Fact]
         public void SeeAlsoCref()
         {
             AssertNullabilityInference(@"

--- a/NullabilityInference/EdgeBuildingOperationVisitor.cs
+++ b/NullabilityInference/EdgeBuildingOperationVisitor.cs
@@ -1584,6 +1584,9 @@ namespace ICSharpCode.NullabilityInference
             return GetDeconstructorMethod(deconstructOperation, parameterCount).Parameters.Select(p => typeSystem.GetSymbolType(p)).ToArray();
         }
 
+        /// <remarks>
+        /// Request for full version of this to be added to the Roslyn API: https://github.com/dotnet/roslyn/issues/33590
+        /// </remarks>
         private static IMethodSymbol GetDeconstructorMethod(IDeconstructionAssignmentOperation deconstructOperation, int parameterCount)
         {
             return deconstructOperation.Value.Type.GetMembers("Deconstruct").OfType<IMethodSymbol>()

--- a/NullabilityInference/TypeSystem.cs
+++ b/NullabilityInference/TypeSystem.cs
@@ -562,7 +562,7 @@ namespace ICSharpCode.NullabilityInference
                     target = targetSubstitution.Value[tp.TypeParameterKind, tp.FullOrdinal()];
                     targetSubstitution = null;
                 }
-                Debug.Assert(source.Type?.TypeKind == target.Type?.TypeKind);
+                Debug.Assert(source.Type?.TypeKind == target.Type?.TypeKind, "Type kinds do not match");
                 if (source.Type is INamedTypeSymbol namedType) {
                     if (!SymbolEqualityComparer.Default.Equals(source.Type?.OriginalDefinition, target.Type?.OriginalDefinition)) {
                         throw new InvalidOperationException($"Types don't match: {source.Type} vs. {target.Type}");


### PR DESCRIPTION
Makes an effort to find the deconstruct method (in common case) and map to its parameters

This seemed like roughly the right thing to be doing in a general sense, but I haven't thought all that deeply about specific cases.
With this and #7 , the inference succeeds on the CodeConverter core library and cuts down from ~480 warnings to ~170 warnings 😄 